### PR TITLE
Make pandas optional dependency

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -17,7 +17,7 @@ Installation
 
 - Python 2.7, 3.3+
 - `Django <http://www.djangoproject.com/>`_ >= 1.5
-- Pandas
+- (optional) Pandas
     - Numpy
     - python-dateutil
     - pytz
@@ -25,6 +25,13 @@ Installation
 To install::
 
     pip install django-csv-exports
+
+or to include the optional dependency::
+
+    pip install django-csv-exports[pandas]
+
+Exporting with pandas may be faster than the standard library under certain
+circumstances, test with your dataset.
 
 Next add `django_exports` to your `INSTALLED_APPS` to include the related css/js::
 

--- a/django_csv_exports/admin.py
+++ b/django_csv_exports/admin.py
@@ -1,10 +1,5 @@
 import csv
 
-try:
-    import pandas
-except ImportError:
-    pandas = None
-
 import django
 from django.conf import settings
 from django.contrib import admin
@@ -17,6 +12,13 @@ def export_as_csv(admin_model, request, queryset):
     Generic csv export admin action.
     based on http://djangosnippets.org/snippets/1697/
     """
+
+    # import pandas lazily as to not slow down ./manage.py
+    try:
+        import pandas
+    except ImportError:
+        pandas = None
+
     # everyone has perms to export as csv unless explicitly defined
     if getattr(settings, 'DJANGO_EXPORTS_REQUIRE_PERM', None):
         admin_opts = admin_model.opts

--- a/django_csv_exports/admin.py
+++ b/django_csv_exports/admin.py
@@ -49,7 +49,7 @@ def export_as_csv(admin_model, request, queryset):
             writer = csv.writer(response)
             writer.writerow(list(field_names))
             for obj in queryset:
-                writer.writerow([text(getattr(obj, field)).encode("utf-8", "replace") for field in field_names])
+                writer.writerow([text(getattr(obj, field)) for field in field_names])
         return response
     return HttpResponseForbidden()
 export_as_csv.short_description = "Export selected objects as csv file"

--- a/setup.py
+++ b/setup.py
@@ -35,10 +35,12 @@ setup(
     long_description=read_file('README.rst'),
     test_suite="runtests.runtests",
     zip_safe=False,
-    install_requires=[
-        'pandas',
-        'numpy',
-        'python-dateutil',
-        'pytz'
-    ]
+    extras_require={
+        'pandas': [
+            'pandas',
+            'numpy',
+            'python-dateutil',
+            'pytz'
+        ]
+    }
 )


### PR DESCRIPTION
pandas/numpy can be very slow to import, in some cases it takes multiple seconds to import pandas and it's also a huge library with a huge dependency on numpy, which can be a pain to install if you don't have binary package. This change makes panda an extra dependency so django-csv-exports can automatically use it when it's available, but otherwise use standard library csv module, and to load pandas lazily so it doesn't slow down running unrelated ./manage.py commands when the user has django-csv-exports installed in INSTALLED_APPS.